### PR TITLE
Add markdownlint configuration file

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,10 @@
+{
+  "no-emphasis-as-heading": false,
+  "blanks-around-headings": false,
+  "no-inline-html": false,
+  "line-length": false,
+  "list-marker-space": false,
+  "blanks-around-lists": false,
+  "first-line-heading": false,
+  "header-increment": false
+}


### PR DESCRIPTION
Vi skriver ganske mye markdown her. Så tenkte kanskje det var greit å legge til en konfigurasjonsfil for markdownlint.

Det gjør at markdownlint ikke klager på absolutt alt i markdown dokumentene våre.

F.eks. [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint) extension i VS Code benytter seg av denne.